### PR TITLE
Progress hook integration for proper return value to slack interface

### DIFF
--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -125,6 +125,7 @@ def saveplaylist(data, playid):
 @plgn.command('startplaylist')
 def continueplaylist(*args, **kwargs):
     """ DONT USE THIS """
+    global downloaded_list
     playids = [i for i in open(plgn.playlistsfile,'r').read().split('\n') if i ]
     logger.debug(playids)
     for i in  playids:
@@ -134,11 +135,11 @@ def continueplaylist(*args, **kwargs):
         except:
             pass
         finally:
-            logger.info('done Downloading id->' +i)
+            logger.info('Done downloading id->' +i)
+            final  = "\n".join(downloaded_list)
+            downloaded_list=[]
+            return "Done downloading. New downloads include "+final
             
-
-
-
 @plgn.command('begin')
 def begin(data,what = None):
     if not os.access(plgn.queued_links,os.F_OK):
@@ -149,7 +150,6 @@ def begin(data,what = None):
         os.mkdir(plgn.location)
     data = links.split(",")
     data = data[:-1]
-    plgn.old=os.listdir(plgn.location)
     output=[]
     for link in data:       
         if not link==" " or not link == "":
@@ -165,8 +165,9 @@ def begin(data,what = None):
         with open(plgn.queued_links,'w') as f:
             f.write(",".join(data))
             f.write(",")
-    plgn.new = os.listdir(plgn.location)
-    final = set(plgn.new) - set(plgn.old) 
+    global downloaded_list
+    final = downloaded_list
+    downloaded_list = []
     errors = ['Link = '+str(i) + '\n' + 'Error = '+str(j) for i,j in output if j!='1' ]
     if len(errors)==0:
         msg = "Done downloading \n {0}".format("\n".join(final))
@@ -237,8 +238,6 @@ def init(config=None):
         plgn.playlistsfile = config.get('playlistsfile', 'playlists.txt')
         if not os.path.exists(plgn.playlistsfile):
             open(plgn.playlistsfile,'w')
-    plgn.old = []
-    plgn.new = []
 
 @plgn.command('ip')
 def ip(data, what=None):

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -62,7 +62,7 @@ def link_downloader(*a):
             'outtmpl':plgn.location_video,
             'logger':ydl_logger,
             'nooverwrites':'True',
-            'progress_hooks':[downloader_hook]
+            'progress_hooks':[downloader_hook],
             }
     if len(args)>1 and (args[1] == 'a' or args[1]=='A'):
         y.update({
@@ -92,11 +92,13 @@ def download(data, what,param):
     try:
         link_downloader(what,param)
     except DownloadException as e:
-        return  str(e.msg)
+        logger.debug(str(e))
+        return str(e) 
     plgn.new = os.listdir(plgn.location)
     #final = [i for i in plgn.new if i not in plgn.old]
-    final = "\n".join(downloaded_list)
-    downloaded_list=[]
+    if downloaded_list:
+        final = "\n".join(downloaded_list)
+        downloaded_list=[]
     return "Done downloading "+ "\n" + final
 
 @plgn.command('queue add <(?P<what>[-a-zA-Z0-9 `,;!@#$%^&*()_=.{}:"\?\<\>/\[\'\]\\n]+)> *(?P<param>[aA]+)?')


### PR DESCRIPTION
I have removed the older application of plgn.new and plgn.old lists and have applied progress_hooks to get the proper downloaded files' name. However, the progress_hooks feature doesn't seem to return the postprocessed title of the audio file that we get on passsing the `--extract-audio` flag. This can be however avoided for the time being till we get a better approach to solving the `download_archive` problem we discussed out in another PR.
