### PR TITLE
Modifying the startplaylist(youtubedl.py) function to iterate over all the ids than returning a single id output.

### DIFF
--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -146,14 +146,12 @@ def continueplaylist(*args, **kwargs):
             if downloaded_list:
                 final  = "\n".join(downloaded_list)
                 downloaded_list=[]
-                #return "Done downloading. New downloads include "+final
             else:
                 final = "No new downloads"
-                #return "No New Downloads"
             out[str(i)]=final
     output = '' #defined for generating the finally returnable string from all the dict(key,value) tuples
     for r in out.items():
-        output = output+"For the playlist id"+r[0]+"\n"+r[1]+"\n"
+        output = output+"For the playlist id"+"\n".join(r)+"\n"
     return output
         
             

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -131,6 +131,8 @@ def saveplaylist(data, playid):
 def continueplaylist(*args, **kwargs):
     """ DONT USE THIS """
     global downloaded_list
+    #out = {} defined for storing return values of all the playlist ids
+    out = {}
     playids = [i for i in open(plgn.playlistsfile,'r').read().split('\n') if i ]
     logger.debug(playids)
     for i in  playids:
@@ -144,10 +146,16 @@ def continueplaylist(*args, **kwargs):
             if downloaded_list:
                 final  = "\n".join(downloaded_list)
                 downloaded_list=[]
-                return "Done downloading. New downloads include "+final
+                #return "Done downloading. New downloads include "+final
             else:
-                return "No New Downloads"
-
+                final = "No new downloads"
+                #return "No New Downloads"
+            out[str(i)]=final
+    output = '' #defined for generating the finally returnable string from all the dict(key,value) tuples
+    for r in out.items():
+        output = output+"For the playlist id"+r[0]+"\n"+r[1]+"\n"
+    return output
+        
             
 @plgn.command('begin')
 def begin(data,what = None):


### PR DESCRIPTION
Referred to issue #5.
* I have made a dict and a string to store the output of all the playlist ids and then return the output all at once.
* For the output, refer to [this](https://github.com/sum12/python-rtmbot/blob/issue%235/plugins/youtube.py#L156)
